### PR TITLE
BUG Use civis-jupyter-notebook which doesn't clobber dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+## [1.1.1] - 2017-11-28
+
+### Fixed
+- Increase ``civis-jupyter-notebook`` version from v0.2.2 to v0.2.4 to get bugfix with relaxed dependency requirements (#4).
+
 ## [1.1.0] - 2017-11-27
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ENV LANG=en_US.UTF-8 \
     CIVIS_CONDA_VERSION=4.3.30 \
     CIVIS_PYTHON_VERSION=2.7.13 \
     DEFAULT_KERNEL=python2 \
-    CIVIS_JUPYTER_NOTEBOOK_VERSION=0.2.2 \
+    CIVIS_JUPYTER_NOTEBOOK_VERSION=0.2.4 \
     TINI_VERSION=v0.16.1
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update -y --no-install-recommends && \


### PR DESCRIPTION
The versions of `civis-jupyter-notebook` <0.2.4 have strict requirements which, for example, will force a downgrade to `civis==1.6`. Update to a bugfix version with more permissive requirements.