### PR TITLE
Git integration with notebooks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -107,7 +107,7 @@ RUN chmod +x /tini
 
 ###############################################
 # Notebook-specific configuration is below here
-RUN pip install git+https://github.com/civisanalytics/civis-jupyter-notebook.git@be70811509f33e3689a7eeaca15e6db7a706feda && \
+RUN pip install git+https://github.com/civisanalytics/civis-jupyter-notebook.git@4555ee18342a7dfad6fe82cb386303b1d69452d8 && \
     civis-jupyter-notebooks-install
 
 EXPOSE 8888

--- a/Dockerfile
+++ b/Dockerfile
@@ -107,7 +107,7 @@ RUN chmod +x /tini
 
 ###############################################
 # Notebook-specific configuration is below here
-RUN pip install git+https://github.com/civisanalytics/civis-jupyter-notebook.git@2d5d71daa4bc6d66c557a4eaa81a2081090eecf8 && \
+RUN pip install git+https://github.com/civisanalytics/civis-jupyter-notebook.git@5ff00365dd4a8b92d261d652693d3d7d3a75141f && \
     civis-jupyter-notebooks-install
 
 EXPOSE 8888

--- a/Dockerfile
+++ b/Dockerfile
@@ -107,7 +107,7 @@ RUN chmod +x /tini
 
 ###############################################
 # Notebook-specific configuration is below here
-RUN pip install git+https://github.com/civisanalytics/civis-jupyter-notebook.git@3bf34eb2dbc36ea7f7db131fc41aced8dea79607 && \
+RUN pip install git+https://github.com/civisanalytics/civis-jupyter-notebook.git@be70811509f33e3689a7eeaca15e6db7a706feda && \
     civis-jupyter-notebooks-install
 
 EXPOSE 8888

--- a/Dockerfile
+++ b/Dockerfile
@@ -107,7 +107,7 @@ RUN chmod +x /tini
 
 ###############################################
 # Notebook-specific configuration is below here
-RUN pip install git+https://github.com/civisanalytics/civis-jupyter-notebook.git@5ff00365dd4a8b92d261d652693d3d7d3a75141f && \
+RUN pip install git+https://github.com/civisanalytics/civis-jupyter-notebook.git@c1e082f9e6a9a7c1606554dc016f2de69b0fc4cc && \
     civis-jupyter-notebooks-install
 
 EXPOSE 8888

--- a/Dockerfile
+++ b/Dockerfile
@@ -107,7 +107,7 @@ RUN chmod +x /tini
 
 ###############################################
 # Notebook-specific configuration is below here
-RUN pip install git+https://github.com/civisanalytics/civis-jupyter-notebook.git@4555ee18342a7dfad6fe82cb386303b1d69452d8 && \
+RUN pip install git+https://github.com/civisanalytics/civis-jupyter-notebook.git@2d5d71daa4bc6d66c557a4eaa81a2081090eecf8 && \
     civis-jupyter-notebooks-install
 
 EXPOSE 8888

--- a/Dockerfile
+++ b/Dockerfile
@@ -107,7 +107,7 @@ RUN chmod +x /tini
 
 ###############################################
 # Notebook-specific configuration is below here
-RUN pip install civis-jupyter-notebook==${CIVIS_JUPYTER_NOTEBOOK_VERSION} && \
+RUN pip install git+https://github.com/civisanalytics/civis-jupyter-notebook.git@3bf34eb2dbc36ea7f7db131fc41aced8dea79607 && \
     civis-jupyter-notebooks-install
 
 EXPOSE 8888


### PR DESCRIPTION
This branch builds the Docker image for adding git integration with notebooks. It should always point to the latest commit hash in this PR: civisanalytics/civis-jupyter-notebook#14.