### PR TITLE
Update packages to correspond to datascience-python v4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+## [1.4.0] - 2018-01-25
+### New packages
+- bqplot 0.10.2
+- feather-format 0.4.0
+
+### Package Updates
+- civis 1.7.1 -> 1.8.0
+- civisml-extensions 0.1.5 -> 0.1.6
+- muffnn 1.2.0 -> 2.0.0
+- cloudpickle 0.5.1 -> 0.5.2
+- dask 0.15.4 -> 0.16.1
+- ftputil 3.3.1 -> 3.4
+- tensorflow 1.4.0 -> 1.4.1
+- boto3 1.4.5 -> 1.5.11
+- cython 0.26 -> 0.27.3
+- openblas 0.2.19 -> 0.2.20
+- pandas 0.21.0 -> 0.22.0
+- pyarrow 0.7.1 -> 0.8.0
+- scipy 0.19.1 -> 1.0.0
+- ipywidgets 7.0.0 -> 7.1.0
+- notebook 5.2.0 -> 5.2.2
+
+### Fixed
+- Enabled widgetsnbextension so that ipywidgets works.
+
 ## [1.3.2] - 2018-01-16
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -98,6 +98,13 @@ RUN mkdir -p ${HOME}/.config/matplotlib && \
     echo "backend      : Agg" > ${HOME}/.config/matplotlib/matplotlibrc && \
     python -c "import matplotlib.pyplot"
 
+# Enable widgetsnbextension for jupyter widgets.
+# See https://ipywidgets.readthedocs.io/en/stable/user_install.html.
+# This enables the extension in the conda environment. The conda-forge version
+# does this upon installation, but the default channel version doesn't seem to,
+# so we'll run this (again) just in case.
+RUN jupyter nbextension enable --py widgetsnbextension
+
 # Instruct joblib to use disk for temporary files. Joblib defaults to
 # /shm when that directory is present. In the Docker container, /shm is
 # present but defaults to 64 MB.

--- a/circle.yml
+++ b/circle.yml
@@ -17,4 +17,4 @@ test:
     - docker run civisanalytics/civis-jupyter-python2 python -c "from numpy.distutils import system_info; assert system_info.get_info('mkl') == {}"
     - docker run civisanalytics/civis-jupyter-python2 python -c "import numpy; numpy.test()"
     - docker run civisanalytics/civis-jupyter-python2 /bin/bash -c "conda list|grep conda-forge"
-    - docker run civisanalytics/civis-jupyter-python2 /bin/bash -c "conda list|grep -c conda-forge|python -c \"import sys; actual_count = int(sys.stdin.readlines()[0]); expected_count = 6; assert actual_count == expected_count, 'There should be %d conda-forge packages, but there are actually %d.' % (expected_count, actual_count)\""
+    - docker run civisanalytics/civis-jupyter-python2 /bin/bash -c "conda list|grep -c conda-forge|python -c \"import sys; actual_count = int(sys.stdin.readlines()[0]); expected_count = 10; assert actual_count == expected_count, 'There should be %d conda-forge packages, but there are actually %d.' % (expected_count, actual_count)\""

--- a/environment.yml
+++ b/environment.yml
@@ -6,10 +6,12 @@ dependencies:
 - beautifulsoup4=4.5.3
 - botocore=1.5.38
 - boto=2.46.1
-- boto3==1.4.5
-- cython=0.26
-- ipykernel=4.6.1
+- boto3==1.5.11
+- bqplot=0.10.2
+- cython=0.27.3
+- feather-format=0.4.0
 - ipython=5.3.0
+- ipywidgets=7.1.0
 - jinja2=2.9.6
 - jsonschema=2.5.1
 - jupyter=1.0.0
@@ -19,15 +21,15 @@ dependencies:
 - libxml2=2.9.2
 - matplotlib=2.1.0
 - nomkl=1.0
+- notebook=5.2.2
 - nose=1.3.7
-- notebook=5.0
 - numexpr=2.6.2
 - numpy=1.13.3
-- openblas=0.2.19
-- pandas=0.21.0
+- openblas=0.2.20
+- pandas=0.22.0
 - patsy=0.4.1
 - psycopg2=2.6.2
-- pyarrow=0.7.1
+- pyarrow=0.8.0
 - pycrypto=2.6.1
 - pytest=3.1.3
 - python=2.7.13
@@ -35,25 +37,25 @@ dependencies:
 - requests=2.18.4
 - s3fs=0.1.2
 - seaborn=0.8
-- scipy=0.19.1
+- scipy=1.0.0
 - scikit-learn=0.19.1
 - statsmodels=0.8.0
 - xgboost=0.6a2
 - pip:
   - awscli==1.11.75
-  - civis==1.7.1
-  - civisml-extensions==0.1.5
-  - cloudpickle==0.5.1
+  - civis==1.8.0
+  - civisml-extensions==0.1.6
+  - cloudpickle==0.5.2
   - dask==0.15.4
   - dropbox==7.1.1
-  - ftputil==3.3.1
+  - ftputil==3.4
   - glmnet==2.0.0
   - joblib==0.11.0
-  - muffnn==1.2.0
+  - muffnn==2.0.0
   - pathlib==1.0.1
   - pubnub==4.0.13
   - pysftp==0.2.9
   - python-simple-hipchat==0.4.0
   - requests-toolbelt==0.8.0
-  - tensorflow==1.4.0
+  - tensorflow==1.4.1
   - urllib3[secure]==1.22


### PR DESCRIPTION
Update packages and Dockerfile to mirror changes in the latest version of datascience-python.

### New packages
- bqplot 0.10.2
- feather-format 0.4.0

### Package Updates
- civis 1.7.1 -> 1.8.0
- civisml-extensions 0.1.5 -> 0.1.6
- muffnn 1.2.0 -> 2.0.0
- cloudpickle 0.5.1 -> 0.5.2
- dask 0.15.4 -> 0.16.1
- ftputil 3.3.1 -> 3.4
- tensorflow 1.4.0 -> 1.4.1
- boto3 1.4.5 -> 1.5.11
- cython 0.26 -> 0.27.3
- openblas 0.2.19 -> 0.2.20
- pandas 0.21.0 -> 0.22.0
- pyarrow 0.7.1 -> 0.8.0
- scipy 0.19.1 -> 1.0.0
- ipywidgets 7.0.0 -> 7.1.0
- notebook 5.2.0 -> 5.2.2

### Fixed
- Enabled widgetsnbextension so that ipywidgets works.
