### PR TITLE
MAINT Update environment to match Python 3 notebooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+
+### Added
+- Added htop and tmux to Linux environment (#14)
+
 ## [1.4.0] - 2018-01-25
 ### New packages
 - bqplot 0.10.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,23 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 
+## [1.5.0] - 2018-04-26
 ### Added
 - Added htop and tmux to Linux environment (#14)
+
+### Package Updates
+- civis 1.8.1 -> 1.9.0
+- civisml-extensions 0.1.6 -> 0.1.8
+- muffnn 2.0.0 -> 2.1.0
+
+- awscli 1.11.75 (pip) -> 1.15.4 (conda)
+- botocore 1.5.38 -> 1.10.4
+- boto3 1.5.11 -> 1.7.4
+- dask 0.15.4 (pip) -> 0.17.2 (conda)
+- tensorflow 1.4.1 -> 1.7.0
+- matplotlib 2.1.0 -> 2.2.2
+- notebook 5.2.2 -> 5.4.1
+- scipy 1.0.0 -> 1.0.1
 
 ## [1.4.0] - 2018-01-25
 ### New packages

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -y --no-install-recommends && 
         curl \
         vim \
         nano \
+        htop \
+        tmux \
         emacs && \
   apt-get clean -y && \
   rm -rf /var/lib/apt/lists/*

--- a/environment.yml
+++ b/environment.yml
@@ -3,12 +3,14 @@ channels:
 - defaults
 - conda-forge
 dependencies:
+- awscli=1.15.4
 - beautifulsoup4=4.5.3
-- botocore=1.5.38
+- botocore=1.10.4
 - boto=2.46.1
-- boto3==1.5.11
+- boto3==1.7.4
 - bqplot=0.10.2
 - cython=0.27.3
+- dask=0.17.2
 - feather-format=0.4.0
 - ipython=5.3.0
 - ipywidgets=7.1.0
@@ -19,9 +21,9 @@ dependencies:
 - libgfortran=3.0.0
 - libtiff=4.0.6
 - libxml2=2.9.2
-- matplotlib=2.1.0
+- matplotlib=2.2.2
 - nomkl=1.0
-- notebook=5.2.2
+- notebook=5.4.1
 - nose=1.3.7
 - numexpr=2.6.2
 - numpy=1.13.3
@@ -37,25 +39,23 @@ dependencies:
 - requests=2.18.4
 - s3fs=0.1.2
 - seaborn=0.8
-- scipy=1.0.0
+- scipy=1.0.1
 - scikit-learn=0.19.1
 - statsmodels=0.8.0
 - xgboost=0.6a2
 - pip:
-  - awscli==1.11.75
-  - civis==1.8.0
-  - civisml-extensions==0.1.6
+  - civis==1.9.0
+  - civisml-extensions==0.1.8
   - cloudpickle==0.5.2
-  - dask==0.15.4
   - dropbox==7.1.1
   - ftputil==3.4
   - glmnet==2.0.0
   - joblib==0.11.0
-  - muffnn==2.0.0
+  - muffnn==2.1.0
   - pathlib==1.0.1
   - pubnub==4.0.13
   - pysftp==0.2.9
   - python-simple-hipchat==0.4.0
   - requests-toolbelt==0.8.0
-  - tensorflow==1.4.1
+  - tensorflow==1.7.0
   - urllib3[secure]==1.22


### PR DESCRIPTION
Include newly-added htop and tmux packages, and update installed package versions to correspond to versions installed with datascience-python v4.2.0. See also civisanalytics/civis-jupyter-python3#22 and https://github.com/civisanalytics/datascience-python/releases/tag/v4.2.0 .

Package changes
- civis 1.8.1 -> 1.9.0
- civisml-extensions 0.1.6 -> 0.1.8
- muffnn 2.0.0 -> 2.1.0

- awscli 1.11.75 (pip) -> 1.15.4 (conda)
- botocore 1.5.38 -> 1.10.4
- boto3 1.5.11 -> 1.7.4
- dask 0.15.4 (pip) -> 0.17.2 (conda)
- tensorflow 1.4.1 -> 1.7.0
- matplotlib 2.1.0 -> 2.2.2
- notebook 5.2.2 -> 5.4.1
- scipy 1.0.0 -> 1.0.1