### PR TITLE
BUG Match numpy version for tensorflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+
 ### Changed
 - Migrate CircleCI build from v1.0 to v2.0 (#15)
+
+### Package Updates
+- numpy 1.13.3 -> 1.14.3 (fixes an error with the tensorflow binary)
+
 
 ## [1.5.0] - 2018-04-26
 ### Added

--- a/environment.yml
+++ b/environment.yml
@@ -26,7 +26,7 @@ dependencies:
 - notebook=5.4.1
 - nose=1.3.7
 - numexpr=2.6.2
-- numpy=1.13.3
+- numpy=1.14.3
 - openblas=0.2.20
 - pandas=0.22.0
 - patsy=0.4.1


### PR DESCRIPTION
Using `numpy` v1.13.3, an `import tensorflow` gave the error "RuntimeError: module compiled against API version 0xc but this version of numpy is 0xb". Update `numpy` to match the version that tensorflow was compiled against. It looks like the "error" only prints to screen but doesn't stop execution, so it's not so easy to test that it's not present.