### PR TITLE
DEP Update civis dependencies for 1.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Migrate CircleCI build from v1.0 to v2.0 (#15)
 
 ### Package Updates
+- civis 1.9.0 -> 1.9.4
+- civisml-extensions 0.1.8 -> 0.1.10
 - numpy 1.13.3 -> 1.14.3 (fixes an error with the tensorflow binary)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+## [1.6.0] - 2019-03-12
 ### Changed
 - Migrate CircleCI build from v1.0 to v2.0 (#15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
-## [1.5.1] - 2019-03-13
+## [1.6.0] - 2019-03-13
 ### Changed
+- Update Ubuntu version to 18.04 (#17)
 - Migrate CircleCI build from v1.0 to v2.0 (#15)
 
 ### Package Updates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
-## [1.6.0] - 2019-03-12
+## [1.5.1] - 2019-03-13
 ### Changed
 - Migrate CircleCI build from v1.0 to v2.0 (#15)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,9 @@
 FROM ubuntu:18.04
 MAINTAINER support@civisanalytics.com
 
-# Ensure UTF-8 locale.
-RUN locale-gen en_US.UTF-8
-
-# Set environment variables for UTF-8, conda, and shell environments
-ENV LANG=en_US.UTF-8 \
-    LANGUAGE=en_US:en \
-    LC_ALL=en_US.UTF-8 \
-    CONDARC=/opt/conda/.condarc \
-    BASH_ENV=/etc/profile \
-    PATH=/opt/conda/bin:$PATH \
-    CIVIS_CONDA_VERSION=4.3.30 \
-    CIVIS_PYTHON_VERSION=2.7.13 \
-    DEFAULT_KERNEL=python2 \
-    CIVIS_JUPYTER_NOTEBOOK_VERSION=0.4.2 \
-    TINI_VERSION=v0.16.1
-
 RUN DEBIAN_FRONTEND=noninteractive apt-get update -y --no-install-recommends && \
+  apt-get install -y --no-install-recommends locales && \
+  locale-gen en_US.UTF-8 && \
   apt-get install -y --no-install-recommends software-properties-common && \
   apt-get install -y --no-install-recommends \
         make \
@@ -40,6 +26,19 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -y --no-install-recommends && 
         emacs && \
   apt-get clean -y && \
   rm -rf /var/lib/apt/lists/*
+
+# Set environment variables for UTF-8, conda, and shell environments
+ENV LANG=en_US.UTF-8 \
+    LANGUAGE=en_US:en \
+    LC_ALL=en_US.UTF-8 \
+    CONDARC=/opt/conda/.condarc \
+    BASH_ENV=/etc/profile \
+    PATH=/opt/conda/bin:$PATH \
+    CIVIS_CONDA_VERSION=4.3.30 \
+    CIVIS_PYTHON_VERSION=2.7.13 \
+    DEFAULT_KERNEL=python2 \
+    CIVIS_JUPYTER_NOTEBOOK_VERSION=0.4.2 \
+    TINI_VERSION=v0.16.1
 
 # Conda install.
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM ubuntu:18.04
 MAINTAINER support@civisanalytics.com
 
 # Ensure UTF-8 locale.

--- a/environment.yml
+++ b/environment.yml
@@ -44,8 +44,8 @@ dependencies:
 - statsmodels=0.8.0
 - xgboost=0.6a2
 - pip:
-  - civis==1.9.0
-  - civisml-extensions==0.1.8
+  - civis==1.9.4
+  - civisml-extensions==0.1.10
   - cloudpickle==0.5.2
   - dropbox==7.1.1
   - ftputil==3.4


### PR DESCRIPTION
This PR updates `civis` and `civisml-extensions` to match functionality and behavior in the Python 3 notebooks. I'm keeping the version updates minimal, since I'm not confident in what supports Python 2 at this point, but I want to keep the notebooks on the same `civis` versions. I'm planning to cut a release after this PR, unless there's anything else that should go in.